### PR TITLE
Add support for L630 bulbs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -515,7 +515,7 @@ class Tapo extends utils.Adapter {
       deviceObject = new P100(this.log, device.ip, this.config.username, this.config.password, 2);
     } else if (device.deviceName.startsWith("P110") || device.deviceName.startsWith("P115")) {
       deviceObject = new P110(this.log, device.ip, this.config.username, this.config.password, 2);
-    } else if (device.deviceName === "L530") {
+    } else if (device.deviceName === "L530" || device.deviceName.startsWith("L630")) {
       deviceObject = new L530(this.log, device.ip, this.config.username, this.config.password, 2);
     } else if (device.deviceName === "L510E") {
       deviceObject = new L510E(this.log, device.ip, this.config.username, this.config.password, 2);


### PR DESCRIPTION
The L630 bulb is basically the same bulb as the L530 but with a GU10 socket. Because the adapter doesn't know it yet it creates a L510E device, which doesn't support setColor. Adding it as L530 device makes setColor work.